### PR TITLE
Add return codes to allow usage in e.g. a commit hook

### DIFF
--- a/src/rg/tools/phpnsc/ClassScanner.php
+++ b/src/rg/tools/phpnsc/ClassScanner.php
@@ -39,6 +39,7 @@ class ClassScanner {
         $this->root = $root;
         $this->namespaceVendor = $namespaceVendor;
         $this->output = $output;
+        $this->foundError = false;
     }
 
     /**
@@ -61,10 +62,12 @@ class ClassScanner {
                 if ($firstStatement instanceof Namespace_) {
                     $namespaceOfFile = implode('\\', $firstStatement->name->parts);
                     if ($namespace !== $namespaceOfFile) {
+                        $this->foundError = true;
                         $this->output->addError('Namespace does not match folder structure, got ' . $namespaceOfFile . ' expected ' . $namespace, $file, $firstStatement->getLine());
                     }
                 }
             } catch (\PhpParser\Error $e) {
+                $this->foundError = true;
                 $this->output->addError(
                     'Parse Error: ' . $e->getMessage(),
                     $file,

--- a/src/rg/tools/phpnsc/Command.php
+++ b/src/rg/tools/phpnsc/Command.php
@@ -62,5 +62,11 @@ class Command extends Console\Command\Command
         $outputClass->printAll();
 
         $outputClass->writeln(\PHP_Timer::resourceUsage());
+
+        if ($classScanner->foundError || $classModifier->foundError) {
+            return 1;
+        } else {
+            return 0;
+        }
     }
 }

--- a/src/rg/tools/phpnsc/NamespaceDependencyChecker.php
+++ b/src/rg/tools/phpnsc/NamespaceDependencyChecker.php
@@ -43,6 +43,7 @@ class NamespaceDependencyChecker {
         $this->root = $root;
         $this->namespaceVendor = $namespaceVendor;
         $this->output = $output;
+        $this->foundError = false;
     }
 
     /**
@@ -147,6 +148,7 @@ class NamespaceDependencyChecker {
     }
 
     private function addMultipleErrors($description, $file, array $lines) {
+        $this->foundError = true;
         foreach ($lines as $line) {
             $this->output->addError($description, $file, $line);
         }


### PR DESCRIPTION
I wanted to write a Git commit hook that would block me from committing if I had any linting errors, but at present `phpnsc` binary doesn't spit out a status code to indicate the presence of errors (which linting tools usually do). This makes it emit a status code 1 on error, which allows it to be used nicely in a hook.