### PR TITLE
Prevent scanning classnames stored in string variables

### DIFF
--- a/src/ClassScanner.php
+++ b/src/ClassScanner.php
@@ -177,7 +177,7 @@ class ClassScanner
         // Extends
         $this->parseFileWithRegexForUsedEntities($file, $namespace, $fileContent, $originalFileContent, '/\sextends\s+([a-zA-Z0-9_\\\]+)\W/i', $this->usedEntities, $reservedClassKeywords);
         // static call
-        $this->parseFileWithRegexForUsedEntities($file, $namespace, $fileContent, $originalFileContent, '/\W([\$a-zA-Z0-9_\\\]+)::/i', $this->usedEntities, $reservedClassKeywords);
+        $this->parseFileWithRegexForUsedEntities($file, $namespace, $fileContent, $originalFileContent, '/[^a-zA-Z0-9_\$]([a-zA-Z0-9_\\\]+)::/i', $this->usedEntities, $reservedClassKeywords);
         // Typehints
         $this->parseFileWithRegexForUsedEntities($file, $namespace, $fileContent, $originalFileContent, '/[\,\(]\s*([a-zA-Z0-9_\\\]+)\s+\$[a-zA-Z0-9_]+/i', $this->usedEntities, $reservedClassKeywords);
 


### PR DESCRIPTION
Currently phpnsc will detect static calls over a classname stored in a string variable and report that the variable name is not a class in the namespace.

Example
```php
static::$trackedClass::getFieldName($field);
```
`example.php (1): Class trackedClass was referenced relatively but not defined`


The edit to the static call Regex should prevent the scanning of classnames that start with a `$`